### PR TITLE
Upgrade Serializer and Adapter for SensorThings API

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -255,6 +255,6 @@ export default DS.RESTAdapter.extend({
       query = this.sortQueryParams(query);
     }
 
-    return this.getNextPage(url, query);
+    return this.getNextPage(url, query, query['$top']);
   },
 });

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -124,14 +124,14 @@ export default DS.RESTAdapter.extend({
     url = this.urlPrefix(url, this.buildURL(type, id, snapshot, 'findHasMany'));
 
     let options = {
-      limit: relationship.options.limit
+      $top: relationship.options['$top']
     };
 
-    if (options.limit === undefined) {
-      options.limit = 50;
+    if (options['$top'] === undefined) {
+      options['$top'] = 50;
     }
 
-    return this.getNextPage(url, options, options.limit);
+    return this.getNextPage(url, options, options['$top']);
   },
 
   /**

--- a/app/models/datastream.js
+++ b/app/models/datastream.js
@@ -7,7 +7,7 @@ export default DS.Model.extend({
   unitOfMeasurement: DS.attr(),
   observationType: DS.attr(),
 
-  observations: DS.hasMany('observation', { limit: 10 }),
+  observations: DS.hasMany('observation', { $top: 10 }),
   observedProperty: DS.belongsTo('observed-property'),
   thing: DS.belongsTo('thing'),
 
@@ -24,7 +24,7 @@ export default DS.Model.extend({
         id: this.get('id'),
         modelName: 'datastream'
       },
-      limit: 50,
+      $top: 50,
       $orderby: 'phenomenonTime desc',
       $filter: 'phenomenonTime ge ' + oneDayAgo.toISOString()
     });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,6 +3,8 @@ import Route from '@ember/routing/route';
 export default Route.extend({
   model() {
     let store = this.get('store');
-    return store.findAll('Thing');
+    return store.query('Thing', {
+      $expand: 'Locations'
+    });
   }
 });

--- a/app/serializers/entity.js
+++ b/app/serializers/entity.js
@@ -72,8 +72,15 @@ export default DS.JSONAPISerializer.extend({
     documentHash.data = [];
 
     payload.forEach((response) => {
-      // TODO: Extract meta information such as the collection size
-      // from the STA response
+      // Extract meta data, if available
+      if (response["@iot.count"]) {
+        documentHash.meta = {
+          total: response["@iot.count"]
+        };
+      }
+
+      // Extract entities from response and transform to data resources
+      // and sideloaded resources
       let entities = response.value;
 
       // If the response is a single entity, convert to array

--- a/app/serializers/entity.js
+++ b/app/serializers/entity.js
@@ -71,7 +71,7 @@ export default DS.JSONAPISerializer.extend({
     // Initialize empty array instead of null value
     documentHash.data = [];
 
-    payload.forEach((response) => {
+    payloadsToParse.forEach((response) => {
       // Extract meta data, if available
       if (response["@iot.count"]) {
         documentHash.meta = {
@@ -85,7 +85,7 @@ export default DS.JSONAPISerializer.extend({
 
       // If the response is a single entity, convert to array
       if (typeOf(response.value) !== "array") {
-        entities = [response.value];
+        entities = [response];
       }
 
       entities.forEach((entity) => {

--- a/app/serializers/entity.js
+++ b/app/serializers/entity.js
@@ -1,187 +1,15 @@
-import { assert, warn } from '@ember/debug';
-import { typeOf, isNone } from '@ember/utils';
 import DS from 'ember-data';
+import { isNone, typeOf } from '@ember/utils';
 
-export default DS.JSONSerializer.extend({
-  primaryKey: '@iot.id',
-
-  coerceId(id) {
-    if (id === null || id === undefined || id === '') { return null; }
-    if (typeof id === 'string') { return id; }
-    return '' + id;
-  },
-
+export default DS.JSONAPISerializer.extend({
   /**
-    Extract any SensorThings API links from the payload into a JSON-API
-    compatible links object.
-    
-    @method extractLinks
-    @param {Object} payload
-    @return {Object} links
-  */
-  extractLinks(payload) {
-    if (payload['@iot.nextLink']) {
-      return {
-        next: payload['@iot.nextLink']
-      };
-    }
-  },
-
-  /**
-    `extractMeta` is used to deserialize any meta information in the
-    adapter payload. By default Ember Data expects meta information to
-    be located on the `meta` property of the payload object.
-    
-    This method has been overridden for SensorThings API. 
-
-    @method extractMeta
-    @param {DS.Store} store
-    @param {DS.Model} modelClass
-    @param {Object} payload
-  */
-  extractMeta(store, typeClass, payload) {
-    if (payload && payload['@iot.count'] !== undefined) {
-      return { count: payload['@iot.count'] };
-    }
-  },
-
-  /**
-    Returns a relationship formatted as a JSON-API "relationship 
-    object".
-
-    http://jsonapi.org/format/#document-resource-object-relationships
-
-    This method has been overridden for SensorThings API.
-
-    @method extractRelationship
-    @param {Object} relationshipModelName
-    @param {Object} relationshipHash
-    @return {Object}
-  */
-  extractRelationships(modelClass, resourceHash) {
-    let relationships = {};
-
-    modelClass.eachRelationship((key, relationshipMeta) => {
-      let relationship = null;
-
-      let linkKey = this.keyForLink(key, relationshipMeta.kind);
-      if (resourceHash[linkKey] !== undefined) {
-        let related = resourceHash[linkKey];
-        relationship = relationship || {};
-        relationship.links = { related };
-      }
-
-      if (relationship) {
-        relationships[key] = relationship;
-      }
-    });
-
-    return relationships;
-  },
-
-  /**
-   `keyForLink` can be used to define a custom key when deserializing 
-   link properties.
-
-   This method has been overridden for SensorThings API.
-
-   @method keyForLink
-   @param {String} key
-   @param {String} kind `belongsTo` or `hasMany`
-   @return {String} normalized key
-  */
-  keyForLink(key, kind) {
-    const keys = {
-      'datastream':       'Datastream',
-      'datastreams':      'Datastreams',
-      'locations':        'Locations',
-      'observations':     'Observations',
-      'observedProperty': 'ObservedProperty',
-      'thing':            'Thing',
-      'things':           'Things'
-    }
-
-    let properKey = keys[key];
-    if (properKey === undefined) {
-      console.warn('Unhandled keyForLink', key);
-    }
-
-    return `${properKey}@iot.navigationLink`;
-  },
-
-  /**
-    `keyForRelationship` can be used to define a custom key when
-    serializing and deserializing relationship properties. By default
-    `JSONSerializer` does not provide an implementation of this method.
-    
-    This method has been overridden for SensorThings API to convert the
-    case of relationships in Ember Data to match the case in SensorThings
-    API entities.
-
-    @method keyForRelationship
-    @param {String} key
-    @param {String} typeClass
-    @param {String} method
-    @return {String} normalized key
-  */
-  keyForRelationship(key, typeClass, method) {
-    const keys = {
-      'datastream':       'Datastream',
-      'datastreams':      'Datastreams',
-      'locations':        'Locations',
-      'observations':     'Observations',
-      'observedProperty': 'ObservedProperty',
-      'thing':            'Thing',
-      'things':           'Things'
-    }
-
-    let properKey = keys[key];
-    if (properKey === undefined) {
-      console.warn('Unhandled keyForLink', key);
-    }
-
-    return properKey;
-  },
-
-   /**
-    In SensorThings API, a request may be paginated server-side. The 
-    Ember Adapter is set up to retrieve the pages recursively up to an
-    optionally specified limit, and return an array of responses to the
-    Ember Store, which passes that to here as the payload.
-
-    An array of responses must be reduced to a single payload object
-    that can be normalized using the generic normalizer.
-
-    This method has been overridden for SensorThings API.
-
-    @method normalizeArrayResponse
-    @param {DS.Store} store
-    @param {DS.Model} primaryModelClass
-    @param {Object} payload
-    @param {String|Number} id
-    @param {String} requestType
-    @return {Object} JSON-API Document
-  */
-  normalizeArrayResponse(store, primaryModelClass, payload, id, requestType) {
-    return payload.reduce((newPayload, aPayload) => {
-      let normalized = this.normalizeResponseGeneric(store, primaryModelClass, aPayload, id, requestType, false);
-      newPayload.data = newPayload.data.concat(normalized.data);
-      return newPayload;
-    }, {
-      data: []
-    });
-  },
-
-  /**
-    The `normalizeResponse` method is used to normalize a payload from the
-    server to a JSON-API Document.
+    The `normalizeResponse` method is used to normalize a payload from
+    OGC SensorThings API to a JSON:API Document.
 
     http://jsonapi.org/format/#document-structure
-
+    
     This method delegates to a more specific normalize method based on
     the `requestType`.
-
-    This method has been overridden for SensorThings API.
 
     @method normalizeResponse
     @param {DS.Store} store
@@ -189,140 +17,79 @@ export default DS.JSONSerializer.extend({
     @param {Object} payload
     @param {String|Number} id
     @param {String} requestType
-    @return {Object} JSON-API Document
+    @return {Object} JSON:API Document
   */
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
-    switch (requestType) {
-      case 'findRecord':
-        // This is a single record
-        return this.normalizeResponseGeneric(...arguments, true);
-      case 'queryRecord':
-        return this.normalizeResponseGeneric(...arguments);
-      case 'findAll':
-        return this.normalizeFindAllResponse(...arguments);
-      case 'findBelongsTo':
-        return this.normalizeResponseGeneric(...arguments);
-      case 'findHasMany':
-        return this.normalizeFindHasManyResponse(...arguments);
-      case 'findMany':
-        return this.normalizeResponseGeneric(...arguments);
-      case 'query':
-        return this.normalizeQueryResponse(...arguments);
-      case 'createRecord':
-        return this.normalizeResponseGeneric(...arguments);
-      case 'deleteRecord':
-        return this.normalizeResponseGeneric(...arguments);
-      case 'updateRecord':
-        return this.normalizeResponseGeneric(...arguments);
-    }
-  },
-
-  /**
-    Normalize a findAll response. As this is a SensorThings API entity
-    collection, it is an array of one or more responses.
-
-    This method has been overridden for SensorThings API.
-
-    @method normalizeQueryResponse
-    @param {DS.Store} store
-    @param {DS.Model} primaryModelClass
-    @param {Object} payload
-    @param {String|Number} id
-    @param {String} requestType
-    @return {Object} JSON-API Document
-  */
-  normalizeFindAllResponse(store, primaryModelClass, payload, id, requestType) {
-    return this.normalizeArrayResponse(...arguments);
-  },
-
-  /**
-    Normalize a findHasMany response. As this is a SensorThings API 
-    entity collection, it is an array of one or more responses.
-
-    This method has been overridden for SensorThings API.
-
-    @method normalizeFindHasManyResponse
-    @param {DS.Store} store
-    @param {DS.Model} primaryModelClass
-    @param {Object} payload
-    @param {String|Number} id
-    @param {String} requestType
-    @return {Object} JSON-API Document
-  */
-  normalizeFindHasManyResponse(store, primaryModelClass, payload, id, requestType) {
-    return this.normalizeArrayResponse(...arguments);
-  },
-
-  /**
-    Normalize a query response. As this is a SensorThings API entity
-    collection, it is an array of one or more responses.
-
-    This method has been overridden for SensorThings API.
-
-    @method normalizeQueryResponse
-    @param {DS.Store} store
-    @param {DS.Model} primaryModelClass
-    @param {Object} payload
-    @param {String|Number} id
-    @param {String} requestType
-    @return {Object} JSON-API Document
-  */
-  normalizeQueryResponse(store, primaryModelClass, payload, id, requestType) {
-    return this.normalizeArrayResponse(...arguments);
-  },
-
-   /*
-    Method based on DS.RestSerializer's generic response normalizer.
-
-    This method has been re-defined for SensorThings API.
-
-    @method normalizeResponseGeneric
-    @private
-    @param {DS.Store} store
-    @param {DS.Model} primaryModelClass
-    @param {Object} payload
-    @param {String|Number} id
-    @param {String} requestType
-    @param {Boolean} isSingle
-    @return {Object} JSON-API Document
-  */
-  normalizeResponseGeneric(store, primaryModelClass, payload, id, requestType, isSingle) {
     let documentHash = {
-      data: null
+      data: null,
+      included: []
     };
 
-    let meta = this.extractMeta(store, primaryModelClass, payload);
-    if (meta) {
-      assert(
-        'The `meta` returned from `extractMeta` has to be an object, not "' + typeof(meta) + '".',
-        typeof(meta) === 'object'
-      );
-      documentHash.meta = meta;
-    }
-
-    let links = this.extractLinks(payload);
-    if (links) {
-      assert(
-        'The `links` returned from `extractLinks` has to be an object, not "' + typeof(links) + '".',
-        typeof(links) === 'object'
-      );
-      documentHash.links = links;
-    }
-
-    if (isSingle || requestType === "findBelongsTo") {
-      let { data } = this.normalize(primaryModelClass, payload);
-      documentHash.data = data;
+    // If payload is an array, parse each set of responses one at a time
+    if (typeOf(payload) !== "array") {
+      console.error("Unhandled payload type")
     } else {
-      let ret = new Array(payload.value.length);
-      for (let i = 0, l = payload.value.length; i < l; i++) {
-        let item = payload.value[i];
-        let { data } = this.normalize(primaryModelClass, item);
-        ret[i] = data;
-      }
+      // Initialize empty array instead of null value
+      documentHash.data = [];
 
-      documentHash.data = ret;
+      payload.forEach((response) => {
+        // TODO: Extract meta information such as the collection size
+        // from the STA response
+
+        // If the response is a single entity
+        if (typeOf(response.value) !== "array") {
+
+        } else {
+          // If the response is a collection of entities
+          let entities = response.value;
+
+          entities.forEach((entity) => {
+            // Convert entity for JSON:API `data` array
+            // TODO: Extract entities retrieved with $expand to the 
+            //       JSON:API `included` array
+            
+            let dataEntity = {
+              id: entity["@iot.id"],
+              type: primaryModelClass.modelName,
+              attributes: entity,
+              relationships: {},
+              links: {}
+            };
+
+            // Remove links from attributes
+            Object.keys(dataEntity.attributes).forEach((key) => {
+              let value = dataEntity.attributes[key];
+
+              // For links to related entities
+              if (key.includes("@iot.navigationLink")) {
+                // Get the name of the relationship from the key.
+                // TODO: Find the correct case and pluralization for
+                // mapping between STA and JSON:API and Ember Data
+                let relationshipName = key.split("@")[0];
+
+                // We use `related` instead of `self` as it is not a
+                // SensorThings API `@iot.selfLink`.
+                dataEntity.relationships[relationshipName] = {
+                  links: { related: value }
+                };
+                delete dataEntity.attributes[key];
+                
+              } else if (key.includes("@iot.selfLink")) {
+                // Copy the self link to the links object
+                dataEntity.links.self = value;
+                delete dataEntity.attributes[key];
+              }
+            });
+
+            // Remove id from attributes
+            delete dataEntity.attributes["@iot.id"];
+
+            documentHash.data.push(dataEntity);
+          });
+        }
+      });
     }
 
     return documentHash;
-  }
+  },
 });

--- a/app/serializers/entity.js
+++ b/app/serializers/entity.js
@@ -1,7 +1,26 @@
 import DS from 'ember-data';
+import { camelize } from '@ember/string';
 import { isNone, typeOf } from '@ember/utils';
 
 export default DS.JSONAPISerializer.extend({
+  /**
+   `keyForRelationship` maps names of relations between entities from
+   SensorThings API (PascalCase) to Ember Data (camelCase).
+
+   The `Ember.String` class is used to do this transformation.
+
+   https://api.emberjs.com/ember/3.1/classes/String
+   
+   @method keyForRelationship
+   @param {String} key
+   @param {String} typeClass
+   @param {String} method
+   @return {String} normalized key
+  */
+  keyForRelationship(key, typeClass, method) {
+    return camelize(key);
+  },
+
   /**
     The `normalizeResponse` method is used to normalize a payload from
     OGC SensorThings API to a JSON:API Document.
@@ -65,7 +84,7 @@ export default DS.JSONAPISerializer.extend({
                 // Get the name of the relationship from the key.
                 // TODO: Find the correct case and pluralization for
                 // mapping between STA and JSON:API and Ember Data
-                let relationshipName = key.split("@")[0];
+                let relationshipName = this.keyForRelationship(key.split("@")[0]);
 
                 // We use `related` instead of `self` as it is not a
                 // SensorThings API `@iot.selfLink`.


### PR DESCRIPTION
This change upgrades from an Ember Data serializer based on the generic JSON serializer class to one based on the JSON:API serializer class. The Ember Data adapter has also been upgraded for compatibility with sending SensorThings API arguments when querying the Ember Data store. This is a read-only Serializer; sending data from Ember to SensorThings API is not supported yet.

Basing the serializer on JSON:API is simpler as the class only needs to transform the response from SensorThings API into a JSON:API document, which is then parsed internally by Ember Data. This does not require the EmbeddedRecords mixin class for extracting records embedded using `$expand`. As JSON:API supports features such as sideloaded resources (similar to `$expand`) and links for resources and relationships (`@iot.navigationLink` in STA), it is a good choice over the generic JSON schema (which is used in the version before this pull request).

I have tested the following commands, all of which work with queries:

* `$count`
* `$expand`
* `$filter`
* `$orderby`
* `$skip`
* `$top`

Here is an example of how to use them:

```javascript
// In a route, or model
let oneDayAgo = new Date(new Date() - 86400 * 1000);
this.get('store').query('observation', {
	$top: 50,
	$orderby: 'phenomenonTime desc',
	$filter: 'phenomenonTime ge ' + oneDayAgo.toISOString()
});
```

The Serializer will automatically convert the entities into Ember Data models to be used locally. These commands can also be specified on relations between Ember Data models, allowing limits (`$top`) or filters to be automatically applied when retrieving entities.

Using `$expand`, Ember Data will automatically minimize the number of requests needed to download Things and Locations, reducing the requests from 151 to 2 (or 1 if a large `$top` is used). If `$expand` is not used, then Ember Data will look for any links on the relationship between two models to retrieve related entities automatically.

Metadata from requests for collections is also parsed, so the `@iot.count` value for a collection query will be available in Ember Data by accessing the `meta` object:

```
    let query = store.query("Thing");
    query.then((q) => {
      console.log(q.get("meta"));
    });
    
    output => { total: 149 }
```

If `$count: false` is specified, then the value will not be present in the response and not available in Ember.

This changeset is necessary to simplify the usage of Ember Data to retrieve entities, and especially with retrieval of embedded entities. It will allow for the optimization of requests using `$filter` and similar, making the web app more responsive by using less bandwidth.